### PR TITLE
Fix repository/bugs URLs in package.json + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ npx proxies-sx-mcp
 ### Option 4: From Source
 
 ```bash
-git clone https://github.com/proxies-sx/mcp-server.git
+git clone https://github.com/bolivian-peru/proxies-sx-mcp-server.git
 cd mcp-server
 npm install
 npm run build

--- a/package.json
+++ b/package.json
@@ -32,11 +32,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/proxies-sx/mcp-server.git"
+    "url": "https://github.com/bolivian-peru/proxies-sx-mcp-server.git"
   },
   "homepage": "https://proxies.sx",
   "bugs": {
-    "url": "https://github.com/proxies-sx/mcp-server/issues"
+    "url": "https://github.com/bolivian-peru/proxies-sx-mcp-server/issues"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
This repo's package.json/README currently point to https://github.com/proxies-sx/mcp-server which does not exist (404).\n\nFixes:\n- package.json: repository.url -> https://github.com/bolivian-peru/proxies-sx-mcp-server.git\n- package.json: bugs.url -> https://github.com/bolivian-peru/proxies-sx-mcp-server/issues\n- README: update clone URL accordingly\n\nRelated: #1